### PR TITLE
Call nl2br() when showing post content to maintain line breaks.

### DIFF
--- a/single.inc.php
+++ b/single.inc.php
@@ -26,7 +26,7 @@
 			$formatted_time = strftime('%b %d %Y %H:%M', $post['post_timestamp']);
 		?>
 		<time class="post-timestamp" datetime="<?= $datetime ?>" data-unix-time="<?= $post['post_timestamp'] ?>"><?= $formatted_time ?></time>
-		<p class="post-message"><?= autolink($post['post_content']) ?></p>
+		<p class="post-message"><?= nl2br(autolink($post['post_content'])) ?></p>
 		<?php else: ?>
 		<p>No post with this ID.</p>
 		<?php endif; ?>

--- a/timeline.inc.php
+++ b/timeline.inc.php
@@ -42,7 +42,7 @@
 					$formatted_time = strftime('%b %d %Y %H:%M', $post['post_timestamp']);
 				?>
 				<a  class="post-timestamp" href="<?= $config['url'] ?>/<?= $post['id'] ?>"><time datetime="<?= $datetime ?>" data-unix-time="<?= $post['post_timestamp'] ?>"><?= $formatted_time ?></time></a>
-				<p class="post-message"><?= autolink($post['post_content']) ?></p>
+				<p class="post-message"><?= nl2br(autolink($post['post_content'])) ?></p>
 			</li>
 			<?php endforeach; ?>
 		</ul>


### PR DESCRIPTION
If the content contains newlines, it is rendered as a single paragraph:

For this input:

    May you do good and not evil.
    May you find forgiveness for yourself and forgive others.
    May you share freely, never taking more than you give.
    
    - D. Richard Hipp, sqlite author

This is the output before this patch:

![image](https://user-images.githubusercontent.com/118391/151268634-c17b17cb-6c4c-4b26-a33d-c462e028d183.png)

And this is the output after:

![image](https://user-images.githubusercontent.com/118391/151268978-ca379352-2738-4212-8ae1-67fc85ed28bd.png)
