### PR TITLE
Handle "💩".length === 2 issue.

### DIFF
--- a/postform.inc.php
+++ b/postform.inc.php
@@ -72,8 +72,7 @@
 			charCount.innerHTML = maxCount;
 
 			textarea.addEventListener('input', function() {
-				// todo: this should probably respect http://blog.jonnew.com/posts/poo-dot-length-equals-two
-				var textLength = this.value.length;
+				var textLength = [...this.value].length;
 
 				charCount.innerHTML = maxCount - textLength;
 			}, false)


### PR DESCRIPTION
Stumbled upon the fix via MDN:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length#unicode

Before:

![image](https://user-images.githubusercontent.com/118391/151684307-0d9f311e-af29-4cfb-b9c9-7fbe6381f083.png)

After:

![image](https://user-images.githubusercontent.com/118391/151684308-dae6e218-21b6-42b5-87b9-979d6ec52fdd.png)

---- 

Still some issues with [Zero Width Joiner](https://emojipedia.org/zero-width-joiner/) emojis (skin tones, groups, etc). Another example. Before:

![image](https://user-images.githubusercontent.com/118391/151684343-3e9e0db3-9a04-4c38-9fde-087dd41a7957.png)

After:

![image](https://user-images.githubusercontent.com/118391/151684386-9d0249e1-95ca-4c89-93ba-b3685231cdc7.png)

But better. 🤷🏽‍♂️