### PR TITLE
Convert $config['show_edits'] reference to $settings['show_edit']

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@
 	// check user credentials
 	$config['logged_in'] = check_login();
 
-	$config['show_edits'] = !empty($config['show_edits']) ? $config['show_edits'] : true;
+	$settings['show_edits'] = !empty($settings['show_edits']) ? $settings['show_edits'] : true;
 
 	// subpages
 	$template = 'timeline';


### PR DESCRIPTION
$config asignment this late was stomping on $settings and always displaying edit status even when set to false in settings. Removing the line entirely also resolves the issue, but might be an issue for upgraded installs.